### PR TITLE
Enable core library desugaring

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -14,6 +14,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
@@ -42,4 +43,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
 }


### PR DESCRIPTION
## Summary
- enable core library desugaring in the Android build
- depend on `desugar_jdk_libs` 2.0.4

## Testing
- `gradle build` *(fails: `/workspace/botanicareflu/android/local.properties (No such file or directory)`)*

------
https://chatgpt.com/codex/tasks/task_e_6849510f7d488332b42f261495efa18f